### PR TITLE
Bug in signature computation

### DIFF
--- a/ark/featureTree.ml
+++ b/ark/featureTree.ml
@@ -15,6 +15,7 @@ let fv_leq a b =
 
 type 'a node =
   { value : int;
+    feature : int;
     left : 'a tree;
     right : 'a tree }
 
@@ -32,49 +33,56 @@ let empty features =
   { features = features;
     tree = Leaf [] }
 
+let rec inv bucket =
+  match bucket with
+  | ((fv,_)::(fv',y)::rs) ->
+    compare_fv fv fv' < 0
+    && inv (List.tl bucket)
+  | _ -> true
+
 let rec insert_bucket fv elt = function
   | (fv', elts)::xs ->
     begin match compare_fv fv fv' with
       | 0 -> (fv, elt::elts)::xs
       | x when x < 0 -> (fv,[elt])::((fv', elts)::xs)
-      | _ -> (fv',elts)::(insert_bucket fv elt xs)
+      | _ ->
+        (fv',elts)::(insert_bucket fv elt xs)
     end
-  | xs -> (fv,[elt])::xs
+  | [] -> [fv,[elt]]
 
-let rec mk_tree feature bucket =
-  if List.length bucket <= bucket_size || feature < 0 then
+let rec mk_tree nb_features bucket =
+  if List.length bucket <= bucket_size then
     Leaf bucket
   else
-    let bucket =
-      BatList.stable_sort
-        (fun (fv,_) (fv',_) -> Pervasives.compare fv.(feature) fv'.(feature))
-        bucket
+    let (feature,value) =
+      let len = List.length bucket in
+      let ft = fst (List.nth bucket (Random.int len)) in
+      let leq = Array.make nb_features 0 in
+      bucket |> List.iter (fun (x, _) ->
+          for i = 0 to nb_features - 1; do
+            if x.(i) <= ft.(i) then
+              leq.(i) <- leq.(i) + 1
+          done);
+      let mid = (len+1) / 2 in
+      let feature = ref 0 in
+      let size = ref (abs (mid - leq.(0))) in
+      for i = 0 to nb_features - 1; do
+        let size' = abs (mid - leq.(i)) in
+        if (size' < (!size) || (size' = (!size) && Random.bool ())) then begin
+          feature := i;
+          size := size'
+        end
+      done;
+      (!feature, ft.(!feature))
     in
-    let split_value =
-      let rec split n left right =
-        if n = 0 then
-          (left, right)
-        else
-          match right with
-          | r::rs -> split (n - 1) (r::left) right
-          | [] -> assert false
-      in
-      let rec go ls rs value =
-        match ls, rs with
-        | ((fv,_)::ls', _) when fv.(feature) < value -> fv.(feature)
-        | (_, (fv,_)::rs') when fv.(feature) > value -> value
-        | (_::ls', _::rs') -> go ls' rs' value
-        | (_, _) -> max (value - 1) 0
-      in
-      match split (bucket_size / 2 + 1) [] bucket with
-      | (left, (fv,_)::right) -> go left right fv.(feature)
-      | _ -> assert false
+    let (left, right) =
+      List.partition (fun (f,_) -> f.(feature) <= value) bucket
     in
-    let (left, right) = BatList.span (fun (fv,_) -> fv.(feature) <= split_value) bucket in
-    Node { value = split_value;
-           left = mk_tree (feature - 1) left;
-           right = mk_tree (feature - 1) right }
-           
+    Node { value = value;
+           feature = feature;
+           left = mk_tree nb_features left;
+           right = mk_tree nb_features right }
+
 let of_list features list =
   let list =
     List.map (fun elt -> (features elt, elt)) list
@@ -93,20 +101,20 @@ let of_list features list =
   | [] -> empty features
   | (fv,x)::list ->
     { features = features;
-      tree = mk_tree (Array.length fv - 1) (go [] fv [x] list) }
+      tree = mk_tree (Array.length fv) (go [] fv [x] list) }
 
 let insert elt ft =
   let fv = ft.features elt in
   let nb_features = Array.length fv in
-  let rec insert_tree feature = function
-    | Leaf bucket -> mk_tree feature (insert_bucket fv elt bucket)
+  let rec insert_tree = function
+    | Leaf bucket -> mk_tree nb_features (insert_bucket fv elt bucket)
     | Node n ->
-      if fv.(feature) <= n.value then
-        Node { n with left = insert_tree (feature - 1) n.left }
+      if fv.(n.feature) <= n.value then
+        Node { n with left = insert_tree n.left }
       else
-        Node { n with right = insert_tree (feature - 1) n.right }
+        Node { n with right = insert_tree n.right }
   in
-  { ft with tree = insert_tree (nb_features - 1) ft.tree }
+  { ft with tree = insert_tree ft.tree }
 
 let enum ft =
   let rec descend tree rest =
@@ -133,23 +141,26 @@ let enum ft =
 let features ft elt = ft.features elt
 
 let find_leq fv p ft =
+  let rec find f = function
+    | [] -> None
+    | (x::xs) -> if f x then Some x else find f xs
+  in
   let find_bucket (fv', xs) =
     if fv_leq fv' fv then
-      try Some (BatList.find p xs)
-      with Not_found -> None
+      find p xs
     else
       None
   in
-  let rec find_tree feature = function
+  let rec find_tree = function
     | Leaf xs -> BatList.find_map find_bucket xs
     | Node n ->
-      if fv.(feature) <= n.value then
-        find_tree (feature - 1) n.left
+      if fv.(n.feature) <= n.value then
+        find_tree n.left
       else
-        try find_tree (feature - 1) n.right
-        with Not_found -> find_tree (feature - 1) n.left
+        try find_tree n.left
+        with Not_found -> find_tree n.right
   in
-  find_tree (Array.length fv - 1) ft.tree
+  find_tree ft.tree
 
 let find_leq_map fv f ft =
   let find_bucket (fv', xs) =
@@ -159,16 +170,16 @@ let find_leq_map fv f ft =
     else
       None
   in
-  let rec find_tree feature = function
+  let rec find_tree = function
     | Leaf xs -> BatList.find_map find_bucket xs
     | Node n ->
-      if fv.(feature) <= n.value then
-        find_tree (feature - 1) n.left
+      if fv.(n.feature) <= n.value then
+        find_tree n.left
       else
-        try find_tree (feature - 1) n.right
-        with Not_found -> find_tree (feature - 1) n.left
+        try find_tree n.right
+        with Not_found -> find_tree n.left
   in
-  find_tree (Array.length fv - 1) ft.tree
+  find_tree ft.tree
 
 let remove equal elt ft =
   let fv = ft.features elt in
@@ -178,15 +189,15 @@ let remove equal elt ft =
     else
       (fv', xs)
   in
-  let rec remove_tree feature = function
+  let rec remove_tree = function
     | Leaf xs -> Leaf (BatList.map remove_bucket xs)
     | Node n ->
-      if fv.(feature) <= n.value then
-        Node { n with left = remove_tree (feature - 1) n.left }
+      if fv.(n.feature) <= n.value then
+        Node { n with left = remove_tree n.left }
       else
-        Node { n with right = remove_tree (feature - 1) n.right }
+        Node { n with right = remove_tree n.right }
   in
-  { ft with tree = remove_tree (Array.length fv - 1) ft.tree }
+  { ft with tree = remove_tree ft.tree }
 
 let rebalance ft =
   let rec to_bucket = function

--- a/duet/proofspace.ml
+++ b/duet/proofspace.ml
@@ -878,4 +878,9 @@ let _ =
   CmdLine.register_pass
     ("-proofspace", verify, " Proof space");
   CmdLine.register_config
-    ("-simple", Arg.Set E.config_set_list, " use list of structs")
+    ("-config-rep", Arg.String (function
+         | "list" -> E.config_set_rep := `List
+         | "feature-tree" -> E.config_set_rep := `FeatureTree
+         | "predicate-tree" -> E.config_set_rep := `PredicateTree
+         | s -> Log.errorf "Unknown option to -config-rep: `%s'" s),
+     " Change representation of config sets (list, feature-tree, predicate-tree)")

--- a/pa/cc/matching_stubs.c
+++ b/pa/cc/matching_stubs.c
@@ -70,7 +70,6 @@ extern "C" {
 
 	  size_t predi = Int_val(Field(head, 0));
 	  prop tmp = prop(predi);
-	  int pos = 0;
 	  while (predList != Val_emptylist){
 	      head = Field(predList, 0);
 	      int arg = Int_val(head);
@@ -83,8 +82,6 @@ extern "C" {
 		  ++sig[arg][predi];
 
 	      predList = Field(predList, 1);
-	      ++predi;
-	      ++pos;
 	  }
 	  if (tmp.vars.size() >= 2){
 	      label.push_back(tmp);

--- a/pa/predicateAutomata.mli
+++ b/pa/predicateAutomata.mli
@@ -188,9 +188,8 @@ module MakeEmpty (A : sig
   val alphabet : solver -> A.letter_set
   val vocabulary : solver -> (A.predicate * int) BatEnum.t
 
-  (** Flag controlling the representation of configuration sets.  If [true], a
-      list representation is used. *)
-  val config_set_list : bool ref
+  (** Parameter controlling the representation of configuration sets. *)
+  val config_set_rep : [ `List | `PredicateTree | `FeatureTree ] ref
 
   (** [bounded_empty pa bound] finds [Some] word which is accepted by [pa] and
       uses only indexed letters with index [<= bound]; [None] if there are no

--- a/pa/struct.ml
+++ b/pa/struct.ml
@@ -4,6 +4,9 @@ open Ark
 
 include Log.Make(struct let name = "struct" end)
 
+
+let embed = ref 0
+
 module type Symbol = sig
   type t
   val hash : t -> int
@@ -368,6 +371,7 @@ module Make (P : Symbol) = struct
        (MatchCPP.embeds (MatchCPP.make (x.universe) (props x) (y.universe) (props y))))
 
   let uembeds x y =
+    incr embed;
     (x.universe <= y.universe)
     && (AtomSet.cardinal x.prop <= AtomSet.cardinal y.prop)
     && (PSet.subset (get_preds x) (get_preds y)) (* this is always true when using Search Tree *)

--- a/pa/struct.mli
+++ b/pa/struct.mli
@@ -1,6 +1,8 @@
 (* Finite structures *)
 open PaFormula
 
+val embed : int ref
+
 module type Symbol = sig
   type t
   val hash : t -> int

--- a/patools/patools.ml
+++ b/patools/patools.ml
@@ -363,7 +363,8 @@ let _ =
     let pa =
       if Array.length Sys.argv > 3 then begin
         (match Sys.argv.(2) with
-         | "simple" -> Empty.config_set_list := true
+         | "list" -> Empty.config_set_rep := `List
+         | "featuretree" -> Empty.config_set_rep := `FeatureTree
          | _ -> ());
         load_automaton Sys.argv.(3)
       end else load_automaton Sys.argv.(2)


### PR DESCRIPTION
The offending line is predi++: I think the intention was to keep a separate count for each position within each predicate, but the result was that positions higher than 0 add to the count of some other predicate.  Since signature matching is used to enforce monadic constraints, the result of this is that that some structure embedding queries will give a positive answer even though there is no embedding.